### PR TITLE
adding a warning about aside tags inside other content

### DIFF
--- a/docs/_common/distill_basics.Rmd
+++ b/docs/_common/distill_basics.Rmd
@@ -176,6 +176,8 @@ ggplot(mtcars, aes(hp, mpg)) + geom_point() + geom_smooth()
 
 </aside>
 
+In either case, you **must** make sure that the text in the `aside` tags are not part of any other content (say a sentence or paragraph), or the entire content will be rendered as an `aside`.
+
 ## Table of contents
 
 You can add a table of contents using the `toc` option and specify the depth of headers that it applies to using the `toc_depth` option. For example:


### PR DESCRIPTION
If someone doesn't realize it, they might try to put the `aside` content inside some other content (like a sentence or paragraph), and end up trying to debug why the entire paragraph looks like an aside and doesn't even have a <p> tag on either side of it.

I just want to add a couple of sentences warning people that the <aside> tags have to be on their own.